### PR TITLE
Sort the issues by created attribute

### DIFF
--- a/clone_roles.py
+++ b/clone_roles.py
@@ -45,6 +45,8 @@ class RotationHelper:
             issues = self.weekly_roles_project.get_issue_list(
                 labels=["roles"], status=IssueStatus.all
             )
+            # sort the issues by created attribute from the newest
+            issues.sort(key=lambda issue: issue.created, reverse=True)
             self._previous_week_issues = [
                 self.get_issue_by_title(issue_title, issues)
                 for issue_title in ISSUE_TITLES
@@ -53,7 +55,7 @@ class RotationHelper:
 
     @staticmethod
     def get_issue_by_title(title: str, issues: List[Issue]):
-        # issues are sorted from the most recently updated
+        # issues are sorted from the most recently created
         # so the first found is the most recent
         return next(issue for issue in issues if issue.title == title)
 


### PR DESCRIPTION
By default, the issues are sorted from the most recently updated which can cause that not the most recent issues in general are picked to be cloned.

I think that the problem in the last run of the script was that since we close the issues in the script after creating the new issues, new issues that were not touched the whole week were not the *most recently updated* and therefore the old ones were cloned. Swapping the order of the operations (closing old, creating new) could also fix the issue, but if in some cases the older issues were updated, this could happen again, so this solution seems more reliable.