### PR TITLE
Use secrets.GITHUB_TOKEN

### DIFF
--- a/.github/workflows/rotate_roles.yaml
+++ b/.github/workflows/rotate_roles.yaml
@@ -20,5 +20,5 @@ jobs:
         run: pip install -r requirements.txt
       - name: Clone weekly roles
         env:
-          TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python clone_roles.py

--- a/.github/workflows/rotate_roles.yaml
+++ b/.github/workflows/rotate_roles.yaml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
           python-version: "3.10"
           cache: "pip"
       - name: Install requirements


### PR DESCRIPTION
The `clone_roles.py` works in this repo only so the [automatically created GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) should be enough.

And don't specify token for `setup-python` job. The documentation mentions it only in ["Using setup-python on GHES" section](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-setup-python-on-ghes) which is not our case, so I think it's actually not needed.