### PR TITLE
Revert "Use secrets.GITHUB_TOKEN"

### DIFF
--- a/.github/workflows/rotate_roles.yaml
+++ b/.github/workflows/rotate_roles.yaml
@@ -20,5 +20,5 @@ jobs:
         run: pip install -r requirements.txt
       - name: Clone weekly roles
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
         run: python clone_roles.py

--- a/.github/workflows/rotate_roles.yaml
+++ b/.github/workflows/rotate_roles.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       - name: Install requirements
         run: pip install -r requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,11 @@
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-ast
       - id: check-builtin-literals
@@ -30,12 +30,12 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         args:
           - --max-line-length=100
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.991
     hooks:
       - id: mypy


### PR DESCRIPTION
This reverts commit 15f5bfe46c3d9ee37112b91885024a840475b06d.

We can't use the `GITHUB_TOKEN` to create/clone issues because events created by the github-actions-bot don't trigger a new workflow, and we need `Move new issues into the Kanban board` workflow to be run for each created issue.
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow